### PR TITLE
Mutate one-dimensional arrays

### DIFF
--- a/scripts/array_mutation.toylang
+++ b/scripts/array_mutation.toylang
@@ -1,0 +1,17 @@
+let arr = [1, 2, 3];
+println "arr: ", arr;
+
+arr[2] = 4;
+println "a2(4): ", arr[2];
+
+arr[2] += 1;
+println "a2(5): ", arr[2];
+
+arr[2] *= 5;
+println "a2(25): ", arr[2];
+
+arr[2] -= 13;
+println "a2(12): ", arr[2];
+
+arr[2] **= 2;
+println "a2(144): ", arr[2];

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -12,6 +12,7 @@ pub enum Line {
 pub enum Statement {
     DeclareVar(String, Expr),
     MutateVar(AssignOp, String, Expr),
+    MutateArr(AssignOp, String, Expr, Expr),
     Expression(Expr),
     Return(Expr),
     If(IfStatement, Option<Vec<IfStatement>>, Option<Vec<Statement>>), // (If, Else If, Else)

--- a/src/grammar.rustpeg
+++ b/src/grammar.rustpeg
@@ -14,6 +14,9 @@ pub statement -> Statement
     / ident:identifier whitespace* op:assign_op whitespace* e:expression whitespace* ";" whitespace* {
         Statement::MutateVar(op, ident, e)
     }
+    / ident:identifier idx:brackets whitespace* op:assign_op whitespace* e:expression ";" whitespace* {
+        Statement::MutateArr(op, ident, idx, e)
+    }
     / if_s:if_statement elif_s:elif_statement* else_s:else_statement? {
         let else_if = if elif_s.len() == 0 {
             None

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,6 +47,17 @@ mod tests {
     }
 
     #[test]
+    fn mutate_arrays() {
+        assert!(statement("foo = [1];").is_ok());
+        assert!(statement("foo[0] *= 2;").is_ok());
+        assert!(statement("foo[0] /= 3;").is_ok());
+        assert!(statement("foo[0] += 4;").is_ok());
+        assert!(statement("foo[0] -= 5;").is_ok());
+        assert!(statement("foo[0] %= 6;").is_ok());
+        assert!(statement("foo[0] **= 7;").is_ok());
+    }
+
+    #[test]
     fn eval_bools() {
         assert_eq!(
             expression("true").unwrap(),


### PR DESCRIPTION
So this only mutates one-dimensional arrays now because my Rust game isn't strong enough yet to find an efficient way for multi-dim. Maybe getting a pointer to the nested value and incrementing that so that I don't have to re-set the nested value. But I wouldn't know how to do that right now.

But this could be a new `hacktoberfest` issue. 😄